### PR TITLE
Cache config files and a few other improvements

### DIFF
--- a/src/main/java/xzot1k/plugins/sp/Config.java
+++ b/src/main/java/xzot1k/plugins/sp/Config.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) XZot1K $year. All rights reserved.
+ */
+
+package xzot1k.plugins.sp;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.EntityType;
+import xzot1k.plugins.sp.api.objects.SerializableLocation;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class Config {
+
+    private static Config instance;
+    private static SimplePortals pluginInstance;
+
+    public static Config get() {
+        return instance;
+    }
+
+    public static void load(SimplePortals plugin) {
+        pluginInstance = plugin;
+        plugin.reloadConfig();
+        instance = new Config(plugin.getConfig());
+    }
+
+    public final String mysqlServerName;
+    public final boolean mysqlUseSSL;
+    public final String mysqlDatabase;
+    public final String mysqlTransferTable;
+    public final String mysqlHost;
+    public final String mysqlPort;
+    public final String mysqlUsername;
+    public final String mysqlPassword;
+
+    public final boolean managementTask;
+    public final boolean keepYawPitch;
+    public final boolean maintainVehicleVelocity;
+    public final boolean maintainEntityVelocity;
+
+    public final boolean bypassPortalPermissions;
+    public final boolean vehicleTeleportation;
+    public final boolean blockCreativePortal;
+    public final boolean forceJoin;
+    public final String forceJoinWorld;
+
+    public final Map<String, SerializableLocation> netherPortalLocations;
+    public final Map<String, SerializableLocation> endPortalLocations;
+    public final boolean endOverrideDeath;
+
+    public final EnumSet<EntityType> creatureBlacklist;
+
+    public final int titleFadeIn;
+    public final int titleFadeOut;
+    public final int titleDuration;
+
+    public final boolean usePortalCooldown;
+    public final boolean ptpProtection;
+    public final int cooldownDuration;
+    public final double throwVelocity;
+    public final int commandTickDelay;
+
+    public final boolean itemTransfer;
+    public final int itemTeleportDelay;
+
+    public final String teleportSound;
+    public final String teleportEffect;
+    public final String selectionEffect;
+    public final int selectionDuration;
+    public final String regionEffect;
+    public final int regionDuration;
+
+    private Config(FileConfiguration c) {
+
+        mysqlServerName = c.getString("mysql.server-name");
+        mysqlUseSSL = c.getBoolean("mysql.use-ssl");
+        mysqlDatabase = c.getString("mysql.database");
+        mysqlTransferTable = c.getString("mysql.transfer-table");
+        mysqlHost = c.getString("mysql.host");
+        mysqlPort = c.getString("mysql.port");
+        mysqlUsername = c.getString("mysql.username");
+        mysqlPassword = c.getString("mysql.password");
+
+        managementTask = c.getBoolean("management-task");
+        keepYawPitch = c.getBoolean("keep-teleport-head-axis");
+        maintainVehicleVelocity = c.getBoolean("maintain-vehicle-velocity");
+        maintainEntityVelocity = c.getBoolean("maintain-entity-velocity");
+
+        bypassPortalPermissions = c.getBoolean("bypass-portal-permissions");
+        vehicleTeleportation = c.getBoolean("vehicle-teleportation");
+        blockCreativePortal = c.getBoolean("block-creative-portal-entrance");
+        forceJoin = c.getBoolean("force-join");
+        forceJoinWorld = c.getString("force-join-world");
+
+        netherPortalLocations = loadPortalLocations(c.getStringList("nether-portal-locations"));
+        endPortalLocations = loadPortalLocations(c.getStringList("end-portal-locations"));
+        endOverrideDeath = c.getBoolean("end-portal-locations-handle-death");
+
+        creatureBlacklist = loadEntityBlacklist(c.getStringList("creature-spawning-blacklist"));
+
+        titleFadeIn = c.getInt("titles.fade-in");
+        titleFadeOut = c.getInt("titles.fade-out");
+        titleDuration = c.getInt("titles.display-time");
+
+        usePortalCooldown = c.getBoolean("use-portal-cooldown");
+        ptpProtection = c.getBoolean("portal-to-portal-protection");
+        cooldownDuration = c.getInt("portal-cooldown-duration");
+        throwVelocity = c.getDouble("throw-velocity");
+        commandTickDelay = c.getInt("command-tick-delay");
+
+        itemTransfer = c.getBoolean("item-transfer");
+        itemTeleportDelay = c.getInt("item-teleport-delay");
+
+        teleportSound = c.getString("teleport-sound");
+        teleportEffect = c.getString("teleport-visual-effect");
+        selectionEffect = c.getString("selection-visual-effect");
+        selectionDuration = c.getInt("selection-visual-duration");
+        regionEffect = c.getString("region-visual-effect");
+        regionDuration = c.getInt("region-visual-duration");
+    }
+
+    private Map<String, SerializableLocation> loadPortalLocations(List<String> list) {
+        Map<String, SerializableLocation> map = new HashMap<>();
+
+        for (String line : list) {
+            if (line == null || !line.contains(":") || !line.contains(",")) continue;
+
+            String[] parts = line.split(":");
+            String sourceWorld = parts[0];
+
+            String[] coords = parts[1].split(",");
+            if (coords.length < 6) continue;
+
+            String destWorld = coords[0];
+            double x = Double.parseDouble(coords[1]);
+            double y = Double.parseDouble(coords[2]);
+            double z = Double.parseDouble(coords[3]);
+            float yaw = Float.parseFloat(coords[4]);
+            float pitch = Float.parseFloat(coords[5]);
+
+            map.put(sourceWorld.toLowerCase(), new SerializableLocation(pluginInstance, destWorld, x, y, z, yaw, pitch));
+        }
+
+        return map;
+    }
+
+    public EnumSet<EntityType> loadEntityBlacklist(List<String> list) {
+        EnumSet<EntityType> set = EnumSet.noneOf(EntityType.class);
+
+        if (list == null) return set;
+
+        for (String raw : list) {
+            if (raw == null || raw.isEmpty()) continue;
+
+            // Normalize config entry
+            String fixed = raw.toUpperCase().replace(" ", "_").replace("-", "_");
+
+            try {
+                set.add(EntityType.valueOf(fixed));
+            } catch (IllegalArgumentException ex) {
+                pluginInstance.getLogger().warning("Invalid entity type " + raw);
+            }
+        }
+
+        return set;
+    }
+
+}

--- a/src/main/java/xzot1k/plugins/sp/SimplePortals.java
+++ b/src/main/java/xzot1k/plugins/sp/SimplePortals.java
@@ -136,7 +136,7 @@ public class SimplePortals extends JavaPlugin {
      * Reloads all configs associated with DisplayShops.
      */
     public void reloadConfigs() {
-        reloadConfig();
+        Config.load(this);
 
         if (langFile == null) langFile = new File(getDataFolder(), "lang.yml");
         langConfig = YamlConfiguration.loadConfiguration(langFile);
@@ -208,8 +208,8 @@ public class SimplePortals extends JavaPlugin {
         }
 
         saveDefaultConfigs();
-        reloadConfigs();
         updateConfigs();
+        Config.load(this);
 
         setupDatabase();
 
@@ -238,7 +238,7 @@ public class SimplePortals extends JavaPlugin {
 
     // cross server
     private synchronized void setupDatabase() {
-        final String host = getConfig().getString("mysql.host");
+        final String host = Config.get().mysqlHost;
         if (host == null || host.isEmpty()) return;
 
         try {
@@ -249,12 +249,12 @@ public class SimplePortals extends JavaPlugin {
             }
         } catch (ClassNotFoundException | NoClassDefFoundError ignored) {return;}
 
-        final boolean useSSL = getConfig().getBoolean("mysql.use-ssl");
-        final String databaseName = getConfig().getString("mysql.database"),
-                port = getConfig().getString("mysql.port"), username = getConfig().getString("mysql.username"),
-                password = getConfig().getString("mysql.password"), syntax = ("jdbc:mysql://" + host + ":" + port + "/"
+        final boolean useSSL = Config.get().mysqlUseSSL;
+        final String databaseName = Config.get().mysqlDatabase,
+                port = Config.get().mysqlPort, username = Config.get().mysqlUsername,
+                password = Config.get().mysqlPassword, syntax = ("jdbc:mysql://" + host + ":" + port + "/"
                 + databaseName + "?useSSL=" + (useSSL ? "true" : "false") + "&autoReconnect=true&useUnicode=yes"),
-                transferTable = getConfig().getString("mysql.transfer-table");
+                transferTable = Config.get().mysqlTransferTable;
 
         try {
             databaseConnection = DriverManager.getConnection(syntax, username, password);
@@ -289,7 +289,7 @@ public class SimplePortals extends JavaPlugin {
             extraLine.append(extra[i]);
         }
 
-        final String table = getConfig().getString("mysql.transfer-table");
+        final String table = Config.get().mysqlTransferTable;
         try (PreparedStatement statement = getDatabaseConnection().prepareStatement("INSERT INTO " + table
                 + "(uuid, server, coordinates, commands, extra) VALUES( '" + player.getUniqueId() + "', '" + serverName + "', '" + coordsString + "', '" + commandLine + "', '" + extraLine + "')"
                 + " ON DUPLICATE KEY UPDATE uuid = '" + player.getUniqueId() + "', server = '" + serverName + "', coordinates = '" + coordsString + "', commands = '" + commandLine

--- a/src/main/java/xzot1k/plugins/sp/api/Manager.java
+++ b/src/main/java/xzot1k/plugins/sp/api/Manager.java
@@ -16,13 +16,15 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.BlockIterator;
 import org.bukkit.util.Vector;
-import xzot1k.plugins.sp.Config;
+import xzot1k.plugins.sp.config.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.enums.PointType;
 import xzot1k.plugins.sp.api.exceptions.PortalFormException;
 import xzot1k.plugins.sp.api.objects.Portal;
 import xzot1k.plugins.sp.api.objects.Region;
 import xzot1k.plugins.sp.api.objects.SerializableLocation;
+import xzot1k.plugins.sp.config.LangConfig;
+import xzot1k.plugins.sp.config.LangKey;
 import xzot1k.plugins.sp.core.packets.bar.ABH_Latest;
 import xzot1k.plugins.sp.core.packets.bar.ABH_Old;
 import xzot1k.plugins.sp.core.packets.bar.BarHandler;
@@ -44,8 +46,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.logging.Level;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class Manager {
 
@@ -211,35 +211,6 @@ public class Manager {
      */
     public boolean isNumeric(String string) {
         return string.matches("-?\\\\d+(\\\\.\\\\d+)?");
-    }
-
-    /**
-     * Colors the text passed.
-     *
-     * @param message The message to translate.
-     * @return The colored text.
-     */
-    public String colorText(String message) {
-        String messageCopy = message;
-        if ((!getPluginInstance().getServerVersion().startsWith("v1_15") && !getPluginInstance().getServerVersion().startsWith("v1_14")
-                && !getPluginInstance().getServerVersion().startsWith("v1_13") && !getPluginInstance().getServerVersion().startsWith("v1_12")
-                && !getPluginInstance().getServerVersion().startsWith("v1_11") && !getPluginInstance().getServerVersion().startsWith("v1_10")
-                && !getPluginInstance().getServerVersion().startsWith("v1_9") && !getPluginInstance().getServerVersion().startsWith("v1_8"))
-                && messageCopy.contains("#")) {
-            try {
-                final Pattern hexPattern = Pattern.compile("\\{#([A-Fa-f\\d]){6}}");
-                Matcher matcher = hexPattern.matcher(message);
-                while (matcher.find()) {
-                    final net.md_5.bungee.api.ChatColor hex = net.md_5.bungee.api.ChatColor.of(matcher.group().substring(1,
-                            matcher.group().length() - 1));
-                    final String pre = message.substring(0, matcher.start()), post = message.substring(matcher.end());
-                    matcher = hexPattern.matcher(message = (pre + hex + post));
-                }
-            } catch (IllegalArgumentException ignored) {}
-            return net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', message);
-        }
-
-        return net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', messageCopy);
     }
 
     public void sendBarMessage(Player player, String message) {
@@ -907,8 +878,7 @@ public class Manager {
 
     private boolean selectionWorldCheck(Player player, Region region) {
         if (!region.getPoint1().getWorldName().equalsIgnoreCase(region.getPoint2().getWorldName())) {
-            player.sendMessage(colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("not-same-world-message")));
+            player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NOT_SAME_WORLD));
             return false;
         }
 

--- a/src/main/java/xzot1k/plugins/sp/api/objects/Portal.java
+++ b/src/main/java/xzot1k/plugins/sp/api/objects/Portal.java
@@ -17,7 +17,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
-import xzot1k.plugins.sp.Config;
+import xzot1k.plugins.sp.config.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.enums.Direction;
 import xzot1k.plugins.sp.api.enums.PortalCommandType;
@@ -60,10 +60,11 @@ public class Portal {
         setLastFillMaterial(Material.AIR);
         if (getRegion() != null && getRegion().getPoint1() != null)
             setTeleportLocation(getRegion().getPoint1().asBukkitLocation().clone().add(0, 2, 0));
-        setMessage(getPluginInstance().getLangConfig().getString("portal-message"));
-        setTitle(getPluginInstance().getLangConfig().getString("portal-title-message"));
-        setSubTitle(getPluginInstance().getLangConfig().getString("portal-subtitle-message"));
-        setBarMessage(getPluginInstance().getLangConfig().getString("portal-bar-message"));
+        // TODO: Should these be re-enabled?
+        setMessage("");
+        setTitle("");
+        setSubTitle("");
+        setBarMessage("");
         getPluginInstance().getManager().getPortalMap().put(getPortalId(), this);
     }
 

--- a/src/main/java/xzot1k/plugins/sp/api/objects/Portal.java
+++ b/src/main/java/xzot1k/plugins/sp/api/objects/Portal.java
@@ -17,6 +17,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
+import xzot1k.plugins.sp.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.enums.Direction;
 import xzot1k.plugins.sp.api.enums.PortalCommandType;
@@ -207,7 +208,7 @@ public class Portal {
                     }
                 }
             }
-        }, SimplePortals.getPluginInstance().getConfig().getInt("command-tick-delay"));
+        }, Config.get().commandTickDelay);
     }
 
     /**
@@ -273,7 +274,7 @@ public class Portal {
         if (getServerSwitchName() == null || getServerSwitchName().isEmpty() || getServerSwitchName().equalsIgnoreCase("none")) {
             Location location = getTeleportLocation().asBukkitLocation();
             if (location != null) {
-                if (getPluginInstance().getConfig().getBoolean("keep-teleport-head-axis")) {
+                if (Config.get().keepYawPitch) {
                     location.setYaw(entity.getLocation().getYaw());
                     location.setPitch(entity.getLocation().getPitch());
                 }
@@ -456,7 +457,7 @@ public class Portal {
      * @param player The player to display to.
      */
     public void displayRegion(Player player) {
-        String particleEffect = getPluginInstance().getConfig().getString("region-visual-effect");
+        String particleEffect = Config.get().regionEffect;
         if (particleEffect == null || particleEffect.isEmpty()) return;
 
         HashMap<String, BukkitTask> tasks = getPluginInstance().getManager().getTasks()

--- a/src/main/java/xzot1k/plugins/sp/config/Config.java
+++ b/src/main/java/xzot1k/plugins/sp/config/Config.java
@@ -2,10 +2,11 @@
  * Copyright (c) XZot1K $year. All rights reserved.
  */
 
-package xzot1k.plugins.sp;
+package xzot1k.plugins.sp.config;
 
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.EntityType;
+import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.objects.SerializableLocation;
 
 import java.util.EnumSet;

--- a/src/main/java/xzot1k/plugins/sp/config/LangConfig.java
+++ b/src/main/java/xzot1k/plugins/sp/config/LangConfig.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) XZot1K $year. All rights reserved.
+ */
+
+package xzot1k.plugins.sp.config;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import xzot1k.plugins.sp.SimplePortals;
+
+import java.io.File;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class LangConfig {
+
+    private static LangConfig instance;
+    private static SimplePortals pluginInstance;
+
+    public static void init(SimplePortals plugin) {
+        pluginInstance = plugin;
+
+        if (instance == null)
+            instance = new LangConfig();
+    }
+
+    public static LangConfig get() {
+        return instance;
+    }
+
+    private FileConfiguration config;
+    private File file;
+
+    // Cached messages
+    private final Map<LangKey, String> messages = new EnumMap<>(LangKey.class);
+
+    private LangConfig() { load(); }
+
+    public void load() {
+        try {
+            if (file == null)
+                file = new File(pluginInstance.getDataFolder(), "lang.yml");
+
+            if (!file.exists())
+                pluginInstance.saveResource("lang.yml", false);
+
+            config = YamlConfiguration.loadConfiguration(file);
+
+            messages.clear();
+            for (LangKey key : LangKey.values()) {
+                String raw = config.getString(key.getPath(), "");
+                messages.put(key, colorText(raw));
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public String get(LangKey key) {
+        return messages.getOrDefault(key, "");
+    }
+
+    public String get(LangKey key, Map<String, String> placeholders) {
+        String msg = get(key);
+        return parsePlaceholders(msg, placeholders);
+    }
+
+    public static String parsePlaceholders(String message, Map<String, String> placeholders) {
+        for (Map.Entry<String, String> entry : placeholders.entrySet()) {
+            message = message.replace("{" + entry.getKey() + "}", entry.getValue());
+        }
+        return message;
+    }
+
+    public void reload() { load(); }
+
+    /**
+     * Colors the text passed.
+     *
+     * @param message The message to translate.
+     * @return The colored text.
+     */
+    public static String colorText(String message) {
+        String messageCopy = message;
+        
+        String version = pluginInstance.getServerVersion();
+        
+        if ((!version.startsWith("v1_15") && !version.startsWith("v1_14")
+                && !version.startsWith("v1_13") && !version.startsWith("v1_12")
+                && !version.startsWith("v1_11") && !version.startsWith("v1_10")
+                && !version.startsWith("v1_9") && !version.startsWith("v1_8"))
+                && messageCopy.contains("#")) {
+            try {
+                final Pattern hexPattern = Pattern.compile("\\{#([A-Fa-f\\d]){6}}");
+                Matcher matcher = hexPattern.matcher(message);
+                while (matcher.find()) {
+                    final net.md_5.bungee.api.ChatColor hex = net.md_5.bungee.api.ChatColor.of(matcher.group().substring(1,
+                            matcher.group().length() - 1));
+                    final String pre = message.substring(0, matcher.start()), post = message.substring(matcher.end());
+                    matcher = hexPattern.matcher(message = (pre + hex + post));
+                }
+            } catch (IllegalArgumentException ignored) {}
+            return net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', message);
+        }
+
+        return net.md_5.bungee.api.ChatColor.translateAlternateColorCodes('&', messageCopy);
+    }
+
+    public FileConfiguration getLangConfig() {
+        return config;
+    }
+
+    public File getFile() {
+        return file;
+    }
+}

--- a/src/main/java/xzot1k/plugins/sp/config/LangKey.java
+++ b/src/main/java/xzot1k/plugins/sp/config/LangKey.java
@@ -13,7 +13,6 @@ public enum LangKey {
     PORTAL_EXISTS("portal-exists-message"),
     INVALID_REGION("selected-region-invalid-message"),
     INVALID_PORTAL("portal-invalid-message"),
-    INVALID_WORLD("world-invalid-message"),
     SELECTION_MODE("selection-mode-message"),
     NOT_SAME_WORLD("not-same-world-message"),
     PORTAL_CREATED("portal-created-message"),
@@ -39,22 +38,22 @@ public enum LangKey {
     PORTAL_COMMANDS("portal-commands-message"),
     DM_DISABLED("portal-dm-message"),
     ALREADY_DISABLED("already-disabled-message"),
-    ALREADY_ENABLED("already-enabled-message"),
+    ALREADY_ENABLED("already-enabled-message"), // Unused
     PORTAL_ENABLED("portal-enabled-message"),
-    PORTAL_DISABLED("portal-disabled-message"),
+    PORTAL_DISABLED("portal-disabled-message"), // Unused
     PORTAL_LIST("portal-list-message"),
-    PORTAL_FIND("portal-find-message"),
-    INVALID_RANGE("invalid-range"),
-    INVALID_COOLDOWN("invalid-cooldown"),
-    INVALID_DELAY("invalid-delay"),
-    INVALID_WORLD_KEY("invalid-world"),
+    PORTAL_FIND("portal-find-message"), // Unused
+    INVALID_RANGE("invalid-range"), // Unused
+    INVALID_COOLDOWN("invalid-cooldown"), // Unused
+    INVALID_DELAY("invalid-delay"), // Unused
+    INVALID_WORLD("invalid-world"),
     INVALID_COORDINATE("invalid-coordinate"),
-    NO_FIND_RESULTS("no-find-results"),
-    COOLDOWN_SET("cooldown-set-message"),
-    DELAY_SET("delay-set-message"),
+    NO_FIND_RESULTS("no-find-results"), // Unused
+    COOLDOWN_SET("cooldown-set-message"), // Unused
+    DELAY_SET("delay-set-message"), // Unused
 
-    TELEPORT_TITLE("teleport.title"),
-    TELEPORT_SUBTITLE("teleport.sub-title"),
+    TELEPORT_TITLE("teleport.title"), // Unused
+    TELEPORT_SUBTITLE("teleport.sub-title"), // Unused
 
     TELEPORT_CANCELLED_TITLE("teleport-cancelled.title"),
     TELEPORT_CANCELLED_SUBTITLE("teleport-cancelled.sub-title"),

--- a/src/main/java/xzot1k/plugins/sp/config/LangKey.java
+++ b/src/main/java/xzot1k/plugins/sp/config/LangKey.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) XZot1K $year. All rights reserved.
+ */
+
+package xzot1k.plugins.sp.config;
+
+public enum LangKey {
+
+    PREFIX("prefix"),
+    NO_PERMISSION("no-permission-message"),
+    MUST_BE_PLAYER("must-be-player-message"),
+    PORTAL_EXISTS_AT_LOCATION("portal-location-exists-message"),
+    PORTAL_EXISTS("portal-exists-message"),
+    INVALID_REGION("selected-region-invalid-message"),
+    INVALID_PORTAL("portal-invalid-message"),
+    INVALID_WORLD("world-invalid-message"),
+    SELECTION_MODE("selection-mode-message"),
+    NOT_SAME_WORLD("not-same-world-message"),
+    PORTAL_CREATED("portal-created-message"),
+    PORTAL_DELETED("portal-deleted-message"),
+    MESSAGE_SET("portal-message-set"),
+    PORTAL_LINKED("portal-link-message"),
+    SWITCH_SERVER_SET("switch-server-set-message"),
+    RELOADED("reload-message"),
+    LOCATION_SET("location-set-message"),
+    SWITCH_LOCATION_SET("switch-location-set-message"),
+    REGION_DISPLAYED("region-displayed-message"),
+    POINT1_SET("point-1-set-message"),
+    POINT2_SET("point-2-set-message"),
+    REGION_RELOCATED("region-relocated-message"),
+    COMMAND_ADDED("portal-command-added-message"),
+    COMMANDS_CLEARED("portal-commands-cleared-message"),
+    COMMAND_ONLY_TOGGLED("portal-command-only-toggle-message"),
+    INVALID_PAGE("invalid-page-message"),
+    INVALID_MATERIAL("invalid-material-message"),
+    PORTAL_FILLED("portal-filled-message"),
+    ENTER_COOLDOWN("enter-cooldown-message"),
+    ENTER_NO_PERMISSION("enter-no-permission-message"),
+    PORTAL_COMMANDS("portal-commands-message"),
+    DM_DISABLED("portal-dm-message"),
+    ALREADY_DISABLED("already-disabled-message"),
+    ALREADY_ENABLED("already-enabled-message"),
+    PORTAL_ENABLED("portal-enabled-message"),
+    PORTAL_DISABLED("portal-disabled-message"),
+    PORTAL_LIST("portal-list-message"),
+    PORTAL_FIND("portal-find-message"),
+    INVALID_RANGE("invalid-range"),
+    INVALID_COOLDOWN("invalid-cooldown"),
+    INVALID_DELAY("invalid-delay"),
+    INVALID_WORLD_KEY("invalid-world"),
+    INVALID_COORDINATE("invalid-coordinate"),
+    NO_FIND_RESULTS("no-find-results"),
+    COOLDOWN_SET("cooldown-set-message"),
+    DELAY_SET("delay-set-message"),
+
+    TELEPORT_TITLE("teleport.title"),
+    TELEPORT_SUBTITLE("teleport.sub-title"),
+
+    TELEPORT_CANCELLED_TITLE("teleport-cancelled.title"),
+    TELEPORT_CANCELLED_SUBTITLE("teleport-cancelled.sub-title"),
+
+    TELEPORT_DELAY_TITLE("teleport-delay.title"),
+    TELEPORT_DELAY_SUBTITLE("teleport-delay.sub-title");
+
+    private final String path;
+
+    LangKey(String path) { this.path = path; }
+
+    public String getPath() { return path; }
+}

--- a/src/main/java/xzot1k/plugins/sp/core/Commands.java
+++ b/src/main/java/xzot1k/plugins/sp/core/Commands.java
@@ -15,16 +15,18 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import xzot1k.plugins.sp.Config;
+import xzot1k.plugins.sp.config.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.objects.Portal;
 import xzot1k.plugins.sp.api.objects.Region;
 import xzot1k.plugins.sp.api.objects.SerializableLocation;
+import xzot1k.plugins.sp.config.LangConfig;
+import xzot1k.plugins.sp.config.LangKey;
 
+import javax.swing.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Objects;
 
 public class Commands implements CommandExecutor {
 
@@ -133,8 +135,7 @@ public class Commands implements CommandExecutor {
                 sendHelpPage(sender, "1");
                 return true;
             } else {
-                sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("no-permission-message")));
+                sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
                 return false;
             }
 
@@ -146,15 +147,16 @@ public class Commands implements CommandExecutor {
 
     private void initiateDisableMessages(CommandSender sender, String portalName) {
         if (!sender.hasPermission("simpleportals.dm") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
 
+        HashMap<String, String> placeholders = new HashMap<>();
+        placeholders.put("name", portalName);
+
         Portal portal = getPluginInstance().getManager().getPortal(portalName);
         if (portal == null) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
             return;
         }
 
@@ -163,104 +165,97 @@ public class Commands implements CommandExecutor {
         portal.setSubTitle(null);
         portal.setBarMessage(null);
         portal.save();
-        sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-dm-message"))
-                .replace("{name}", portalName)));
+        sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.DM_DISABLED, placeholders));
     }
 
     private void initiateDisable(CommandSender sender, String portalName) {
         if (!sender.hasPermission("simpleportals.toggle") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
 
+        HashMap<String, String> placeholders = new HashMap<>();
+        placeholders.put("name", portalName);
+
         Portal portal = getPluginInstance().getManager().getPortal(portalName);
         if (portal == null) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
             return;
         }
 
         if (portal.isDisabled()) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("already-disabled-message"))
-                    .replace("{name}", portalName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.ALREADY_DISABLED, placeholders));
             return;
         }
 
         portal.setDisabled(true);
         portal.save();
-        sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-disabled-message"))
-                .replace("{name}", portalName)));
+        sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.DM_DISABLED, placeholders));
     }
 
     private void initiateEnable(CommandSender sender, String portalName) {
         if (!sender.hasPermission("simpleportals.toggle") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
 
+        HashMap<String, String> placeholders = new HashMap<>();
+        placeholders.put("name", portalName);
+
         Portal portal = getPluginInstance().getManager().getPortal(portalName);
         if (portal == null) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL));
             return;
         }
 
         if (!portal.isDisabled()) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("already-enabled-message"))
-                    .replace("{name}", portalName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.ALREADY_DISABLED, placeholders));
             return;
         }
 
         portal.setDisabled(false);
         portal.save();
-        sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-enabled-message"))
-                .replace("{name}", portalName)));
+        sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.PORTAL_ENABLED, placeholders));
     }
 
     private void sendPortalCommands(CommandSender sender, String portalName) {
         if (!sender.hasPermission("simpleportals.viewcommands") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
+
+        HashMap<String, String> placeholders = new HashMap<>();
+        placeholders.put("name", portalName);
 
         Portal portal = getPluginInstance().getManager().getPortal(portalName);
         if (portal == null) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
             return;
         }
 
-        sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-commands-message"))
-                .replace("{commands}", portal.getCommands().toString()).replace("{name}", portalName)));
+        placeholders.put("commands", portal.getCommands().toString());
+
+        sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.PORTAL_COMMANDS, placeholders));
     }
 
     private void initiateFill(CommandSender sender, String portalName, String materialString) {
         if (!sender.hasPermission("simpleportals.fill") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
 
         if (!(sender instanceof Player)) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
             return;
         }
+
+        HashMap<String, String> placeholders = new HashMap<>();
+        placeholders.put("name", portalName);
 
         Player player = (Player) sender;
         Portal portal = getPluginInstance().getManager().getPortal(portalName);
         if (portal == null) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
             return;
         }
 
@@ -274,35 +269,34 @@ public class Commands implements CommandExecutor {
         } else materialName = materialString;
 
         if (materialName == null || materialName.equalsIgnoreCase("")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("invalid-material-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_MATERIAL));
             return;
         }
 
         Material material = Material.getMaterial(materialName.toUpperCase().replace(" ", "_").replace("-", "_"));
         if (material == null) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("invalid-material-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_MATERIAL));
             return;
         }
+        placeholders.put("material", material.toString());
 
         portal.fillPortal(player, material, durability);
         portal.save();
-        sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-filled-message")).replace("{name}", portal.getPortalId()).replace("{material}", material.name())));
+        sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.PORTAL_FILLED, placeholders));
     }
 
     private void setMessage(CommandSender sender, String[] args) {
         if (!sender.hasPermission("simpleportals.message") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
 
+        HashMap<String, String> placeholders = new HashMap<>();
+        placeholders.put("name", args[1]);
+
         Portal portal = getPluginInstance().getManager().getPortal(args[1]);
         if (portal == null) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", args[1])));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
             return;
         }
 
@@ -323,20 +317,21 @@ public class Commands implements CommandExecutor {
             foundType = "Sub-Title";
         } else portal.setMessage(fixedMessage);
         portal.save();
+        placeholders.put("message", fixedMessage);
+        placeholders.put("type", foundType);
 
-        sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-message-set"))
-                .replace("{message}", fixedMessage).replace("{type}", foundType).replace("{name}", portal.getPortalId())));
+        sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MESSAGE_SET, placeholders));
     }
 
     private void addCommand(CommandSender sender, String[] args) {
         if (sender instanceof Player) {
             Player player = (Player) sender;
             if (!player.hasPermission("simpleportals.addcommand") && !sender.hasPermission("simpleportals.admin")) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("no-permission-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
                 return;
             }
+            HashMap<String, String> placeholders = new HashMap<>();
+            placeholders.put("name", args[1]);
 
             Portal portal = getPluginInstance().getManager().getPortal(args[1]);
             if (portal != null) {
@@ -347,93 +342,85 @@ public class Commands implements CommandExecutor {
 
                 String fixedCommand = enteredCommand.toString().replaceAll("(?i):CHAT", "")
                         .replaceAll("(?i):PLAYER", "").replaceAll("(?i):CONSOLE", "");
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-command-added-message"))
-                        .replace("{command}", fixedCommand).replace("{name}", portal.getPortalId())));
+                placeholders.put("command", fixedCommand);
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.COMMAND_ADDED, placeholders));
             } else
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", args[1])));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
     }
 
     private void clearCommands(CommandSender sender, String portalName) {
         if (sender instanceof Player) {
             Player player = (Player) sender;
             if (!player.hasPermission("simpleportals.clearcommands") && !sender.hasPermission("simpleportals.admin")) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("no-permission-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
                 return;
             }
+
+            HashMap<String, String> placeholders = new HashMap<>();
+            placeholders.put("name", portalName);
 
             Portal portal = getPluginInstance().getManager().getPortal(portalName);
             if (portal != null) {
                 portal.getCommands().clear();
                 portal.save();
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-commands-cleared-message"))
-                        .replace("{name}", portal.getPortalId())));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.COMMANDS_CLEARED, placeholders));
             } else
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
     }
 
     private void toggleCommandOnly(CommandSender sender, String portalName) {
         if (sender instanceof Player) {
             Player player = (Player) sender;
             if (!player.hasPermission("simpleportals.togglecommandonly") && !sender.hasPermission("simpleportals.admin")) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("no-permission-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
                 return;
             }
+
+            HashMap<String, String> placeholders = new HashMap<>();
+            placeholders.put("name", portalName);
 
             Portal portal = getPluginInstance().getManager().getPortal(portalName);
             if (portal != null) {
                 portal.setCommandsOnly(!portal.isCommandsOnly());
                 portal.save();
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-command-only-toggle-message"))
-                        .replace("{status}", portal.isCommandsOnly() ? "Enabled" : "Disabled")
-                        .replace("{name}", portal.getPortalId())));
+                placeholders.put("status", portal.isCommandsOnly() ? "Enabled" : "Disabled");
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.COMMAND_ONLY_TOGGLED, placeholders));
             } else
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
     }
 
     private void initiatePortalSwitchLocationSet(CommandSender sender, String... args) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
             return;
         }
 
         Player player = (Player) sender;
         if ((!player.hasPermission("simpleportals.setswitchlocation") || !player.hasPermission("simpleportals.ssl")) && !sender.hasPermission("simpleportals.admin")) {
-            player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
 
+        HashMap<String, String> placeholders = new HashMap<>();
+        placeholders.put("name", args[1]);
+
         Portal portal = getPluginInstance().getManager().getPortal(args[1]);
-        if (portal == null) player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", args[1])));
+        if (portal == null) player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
 
         final String worldName = args[2];
         if (getPluginInstance().getServer().getWorlds().parallelStream().noneMatch(world -> world.getName().equalsIgnoreCase(worldName))) {
-            player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("invalid-world").replace("{world}", worldName)));
+            placeholders.put("world", worldName);
+            player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_WORLD_KEY, placeholders));
             return;
         }
 
-        String invalidCoordMessage = getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                + getPluginInstance().getLangConfig().getString("invalid-coordinate"));
+        String invalidCoordMessage = LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_COORDINATE);
 
         for (int i = 2; ++i < Math.min(args.length, 8); ) {
             if (getPluginInstance().getManager().isNumeric(args[i])) {
@@ -448,51 +435,48 @@ public class Commands implements CommandExecutor {
 
         portal.setServerSwitchLocation(location);
         portal.save();
-        player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("switch-location-set-message"))
-                .replace("{name}", portal.getPortalId())));
+        player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.SWITCH_LOCATION_SET, placeholders));
     }
 
     private void initiatePortalLocationSet(CommandSender sender, String portalName) {
         if (sender instanceof Player) {
             Player player = (Player) sender;
             if ((!player.hasPermission("simpleportals.setlocation") || !player.hasPermission("simpleportals.sl")) && !sender.hasPermission("simpleportals.admin")) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("no-permission-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
                 return;
             }
+
+            HashMap<String, String> placeholders = new HashMap<>();
+            placeholders.put("name", portalName);
 
             Portal portal = getPluginInstance().getManager().getPortal(portalName);
             if (portal != null) {
                 portal.setTeleportLocation(player.getLocation());
                 portal.save();
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("location-set-message"))
-                        .replace("{name}", portal.getPortalId())));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.LOCATION_SET, placeholders));
             } else
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
     }
 
     private void initiatePortalLocationSet(CommandSender sender, String portalName, String otherPortalName) {
         if (sender instanceof Player) {
             Player player = (Player) sender;
             if ((!player.hasPermission("simpleportals.setlocation") || !player.hasPermission("simpleportals.sl")) && !sender.hasPermission("simpleportals.admin")) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("no-permission-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
                 return;
             }
+
+            HashMap<String, String> placeholders = new HashMap<>();
+            placeholders.put("name", otherPortalName);
 
             Portal portal = getPluginInstance().getManager().getPortal(portalName);
             if (portal != null) {
 
                 Portal foundPortal = getPluginInstance().getManager().getPortal(otherPortalName);
                 if (foundPortal == null) {
-                    player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                            + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", otherPortalName)));
+                    player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
                     return;
                 }
 
@@ -502,30 +486,32 @@ public class Commands implements CommandExecutor {
 
                 World world = getPluginInstance().getServer().getWorld(foundPointOne.getWorldName());
                 if (world == null) {
-                    player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                            + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("world-invalid-message")).replace("{name}", foundPointOne.getWorldName())));
+                    placeholders.put("name", foundPointOne.getWorldName());
+                    player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_WORLD, placeholders));
                     return;
                 }
 
                 portal.setTeleportLocation(new Location(world, x + 0.5, y + 0.5, z + 0.5, player.getLocation().getYaw(), player.getLocation().getPitch()));
                 portal.save();
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-link-message"))
-                        .replace("{name}", portal.getPortalId()).replace("{other}", foundPortal.getPortalId())));
-            } else
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+                placeholders.put("name", portal.getPortalId());
+                placeholders.put("other", foundPortal.getPortalId());
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.PORTAL_LINKED, placeholders));
+            } else {
+                placeholders.put("name", portalName);
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
+            }
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
     }
 
     private void initiatePortalCooldown(CommandSender sender, String portalName, String cooldownInSeconds) {
         if (!sender.hasPermission("simpleportals.changecooldown") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
+
+        HashMap<String, String> placeholders = new HashMap<>();
+        placeholders.put("name", portalName);
 
         Portal portal = getPluginInstance().getManager().getPortal(portalName);
         if (portal != null) {
@@ -533,7 +519,7 @@ public class Commands implements CommandExecutor {
             try {
                 cooldownInSecondsInt = Integer.parseInt(cooldownInSeconds);
             } catch (NumberFormatException e) {
-                sender.sendMessage("§cInvalid cooldown entered! Please enter just a number.");
+                sender.sendMessage("§cInvalid cooldown entered! Please enter just a number."); // TODO: Hardcoded
                 return;
             }
 
@@ -543,8 +529,7 @@ public class Commands implements CommandExecutor {
             sender.sendMessage("§aCooldown of portal §b" + portal.getPortalId() + " §asuccessfully set to §e" + cooldownInSecondsInt + " seconds§a.");
 
         } else {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
         }
 
     }
@@ -554,17 +539,18 @@ public class Commands implements CommandExecutor {
         if (sender instanceof Player) {
             Player player = (Player) sender;
             if ((!player.hasPermission("simpleportals.relocate") || !player.hasPermission("simpleportals.rl")) && !sender.hasPermission("simpleportals.admin")) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("no-permission-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
                 return;
             }
 
             Region region = getPluginInstance().getManager().getCurrentSelection(player);
             if (region == null || region.getPoint1() == null || region.getPoint2() == null) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("selected-region-invalid-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_REGION));
                 return;
             }
+
+            HashMap<String, String> placeholders = new HashMap<>();
+            placeholders.put("name", portalName);
 
             Portal portal = getPluginInstance().getManager().getPortal(portalName);
             if (portal != null) {
@@ -572,58 +558,52 @@ public class Commands implements CommandExecutor {
                 portal.save();
                 getPluginInstance().getManager().clearCurrentSelection(player);
                 portal.displayRegion(player);
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("region-relocated-message")).replace("{name}", portal.getPortalId())));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.REGION_RELOCATED, placeholders));
             } else
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
     }
 
     private void initiatePortalRegion(CommandSender sender, String portalName) {
         if (sender instanceof Player) {
             Player player = (Player) sender;
             if ((!player.hasPermission("simpleportals.showregion") || !player.hasPermission("simpleportals.sr")) && !sender.hasPermission("simpleportals.admin")) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("no-permission-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
                 return;
             }
+
+            HashMap<String, String> placeholders = new HashMap<>();
+            placeholders.put("name", portalName);
 
             Portal portal = getPluginInstance().getManager().getPortal(portalName);
             if (portal != null) {
                 portal.displayRegion(player);
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("region-displayed-message")).replace("{name}", portal.getPortalId())));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.REGION_DISPLAYED, placeholders));
             } else
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
     }
 
     private void initiateInfo(CommandSender sender) {
         if (!sender.hasPermission("simpleportals.info") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
 
-        sender.sendMessage(getPluginInstance().getManager().colorText("&d&m-----------------------------"));
+        sender.sendMessage(LangConfig.colorText("&d&m-----------------------------"));
         sender.sendMessage("");
-        sender.sendMessage(getPluginInstance().getManager().colorText(" &7Plugin Name:&r &bSimplePortals"));
-        sender.sendMessage(getPluginInstance().getManager().colorText(" &7Author(s):&r &cXZot1K"));
-        sender.sendMessage(getPluginInstance().getManager().colorText(" &7Plugin Version:&r &a" + getPluginInstance().getDescription().getVersion()));
+        sender.sendMessage(LangConfig.colorText(" &7Plugin Name:&r &bSimplePortals"));
+        sender.sendMessage(LangConfig.colorText(" &7Author(s):&r &cXZot1K"));
+        sender.sendMessage(LangConfig.colorText(" &7Plugin Version:&r &a" + getPluginInstance().getDescription().getVersion()));
         sender.sendMessage("");
-        sender.sendMessage(getPluginInstance().getManager().colorText("&d&m-----------------------------"));
+        sender.sendMessage(LangConfig.colorText("&d&m-----------------------------"));
     }
 
     private void initiateReload(CommandSender sender) {
         if (!sender.hasPermission("simpleportals.reload") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
 
@@ -632,14 +612,12 @@ public class Commands implements CommandExecutor {
             getPluginInstance().getManager().loadPortals();
         }
 
-        sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                + getPluginInstance().getLangConfig().getString("reload-message")));
+        sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.RELOADED));
     }
 
     private void initiateList(CommandSender sender) {
         if (!sender.hasPermission("simpleportals.list") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
 
@@ -648,7 +626,7 @@ public class Commands implements CommandExecutor {
         /*List<String> portalNames = getPluginInstance().getManager().getPortalNames(true);
         StringBuilder stringBuilder = new StringBuilder();
         //Info message before portals
-        stringBuilder.append(getPluginInstance().getLangConfig().getString("prefix")).append(getPluginInstance().getLangConfig().getString("portal-list-message"));
+        stringBuilder.append(LangConfig.get().get(LangKey.PREFIX)).append(getPluginInstance().getLangConfig().getString("portal-list-message"));
         //Actual portals
         for (final String portalName : portalNames){
             stringBuilder.append("\n").append(portalName);
@@ -657,8 +635,7 @@ public class Commands implements CommandExecutor {
 
         //Old version with clickable text which teleports you
         final TextComponent message =
-                new TextComponent(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix") + getPluginInstance().getLangConfig().getString("portal-list" +
-                        "-message")));
+                new TextComponent(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.PORTAL_LIST));
         for (final String portalName : getPluginInstance().getManager().getPortalMap().keySet()) {
             final Portal portal = getPluginInstance().getManager().getPortalMap().get(portalName);
             final int x = (int) ((portal.getRegion().getPoint1().getX() + portal.getRegion().getPoint2().getX()) / 2),
@@ -667,7 +644,7 @@ public class Commands implements CommandExecutor {
 
             final TextComponent portalText = new TextComponent("\n" + getPluginInstance().getManager().getPortalName(portal, true));
             portalText.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                    new BaseComponent[]{new TextComponent(getPluginInstance().getManager().colorText("&bClick to teleport to the portal &a" + portalName))}));
+                    new BaseComponent[]{new TextComponent(LangConfig.colorText("&bClick to teleport to the portal &a" + portalName))})); // TODO: hardcoded
             portalText.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/tppos " + x + " " + y + " " + z + " 0 0 " + portal.getRegion().getPoint1().getWorldName()));
             message.addExtra(portalText);
         }
@@ -678,43 +655,41 @@ public class Commands implements CommandExecutor {
 
     private void initiateSwitchServerSet(CommandSender sender, String portalName, String serverName) {
         if ((!sender.hasPermission("simpleportals.switchserver") || !sender.hasPermission("simpleportals.ss")) && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
+
+        HashMap<String, String> placeholders = new HashMap<>();
+        placeholders.put("name", portalName);
+        placeholders.put("server", serverName);
 
         Portal portal = getPluginInstance().getManager().getPortal(portalName);
         if (portal != null) {
             portal.setServerSwitchName(serverName);
             portal.save();
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("switch-server-set-message"))
-                    .replace("{name}", portal.getPortalId()).replace("{server}", serverName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.SWITCH_SERVER_SET, placeholders));
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
     }
 
     private void initiatePortalDeletion(CommandSender sender, String portalName) {
         if (!sender.hasPermission("simpleportals.delete") && !sender.hasPermission("simpleportals.admin")) {
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("no-permission-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
             return;
         }
+
+        HashMap<String, String> placeholders = new HashMap<>();
+        placeholders.put("name", portalName);
 
         Portal portal = getPluginInstance().getManager().getPortal(portalName);
         if (portal != null) {
             if (sender instanceof Player) getPluginInstance().getManager().clearAllVisuals((Player) sender);
             if (portal.delete()) {
-                sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-deleted-message"))
-                        .replace("{name}", portal.getPortalId())));
+                sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.PORTAL_DELETED, placeholders));
             } else
-                sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+                sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-invalid-message")).replace("{name}", portalName)));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PORTAL, placeholders));
     }
 
     private void initiatePortalCreation(CommandSender sender, String portalName) {
@@ -722,34 +697,32 @@ public class Commands implements CommandExecutor {
             Player player = (Player) sender;
 
             if (!player.hasPermission("simpleportals.create") && !sender.hasPermission("simpleportals.admin")) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("no-permission-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
                 return;
             }
 
+            HashMap<String, String> placeholders = new HashMap<>();
+            placeholders.put("name", portalName);
+
             Portal portal = getPluginInstance().getManager().getPortalAtLocation(player.getLocation());
             if (portal != null) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-location-exists-message")).replace("{name}", portal.getPortalId())));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.PORTAL_EXISTS_AT_LOCATION, placeholders));
                 return;
             }
 
             if (getPluginInstance().getManager().doesPortalExist(portalName)) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-exists-message")).replace("{name}", portalName)));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.PORTAL_EXISTS, placeholders));
                 return;
             }
 
             Region region = getPluginInstance().getManager().getCurrentSelection(player);
             if (region == null || region.getPoint1() == null || region.getPoint2() == null) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("selected-region-invalid-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_REGION));
                 return;
             }
 
             if (!region.getPoint1().getWorldName().equalsIgnoreCase(region.getPoint2().getWorldName())) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("not-same-world-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NOT_SAME_WORLD));
                 return;
             }
 
@@ -757,15 +730,13 @@ public class Commands implements CommandExecutor {
             newPortal.setTeleportLocation(player.getLocation().clone());
             newPortal.save();
             getPluginInstance().getManager().loadPortal(newPortal);
+            placeholders.put("name", newPortal.getPortalId());
 
             newPortal.displayRegion(player);
             getPluginInstance().getManager().clearCurrentSelection(player);
-            player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("portal-created-message"))
-                    .replace("{name}", newPortal.getPortalId())));
+            player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.PORTAL_CREATED, placeholders));
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
     }
 
     private void initiateSelectionMode(CommandSender sender) {
@@ -773,18 +744,17 @@ public class Commands implements CommandExecutor {
             Player player = (Player) sender;
 
             if ((!player.hasPermission("simpleportals.selectionmode") && !player.hasPermission("simpleportals.sm")) && !sender.hasPermission("simpleportals.admin")) {
-                player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                        + getPluginInstance().getLangConfig().getString("no-permission-message")));
+                player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.NO_PERMISSION));
                 return;
             }
 
+            HashMap<String, String> placeholders = new HashMap<>();
+            placeholders.put("status", getPluginInstance().getManager().isInSelectionMode(player) ? "Disabled" : "Enabled");
+
             getPluginInstance().getManager().setSelectionMode(player, !getPluginInstance().getManager().isInSelectionMode(player));
-            player.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("selection-mode-message"))
-                    .replace("{status}", getPluginInstance().getManager().isInSelectionMode(player) ? "Enabled" : "Disabled")));
+            player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.SELECTION_MODE, placeholders));
         } else
-            sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + getPluginInstance().getLangConfig().getString("must-be-player-message")));
+            sender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.MUST_BE_PLAYER));
     }
 
     private void setupHelpPageMap() {
@@ -819,17 +789,20 @@ public class Commands implements CommandExecutor {
 
     private void sendHelpPage(CommandSender commandSender, String pageString) {
         int page;
+
+        HashMap<String, String> placeholders = new HashMap<>();
+
         try {
             page = Integer.parseInt(pageString);
         } catch (Exception ignored) {
-            commandSender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("invalid-page-message")).replace("{pages}", String.valueOf(getHelpPageMap().size()))));
+            placeholders.put("pages", String.valueOf(getHelpPageMap().size()));
+            commandSender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PAGE, placeholders));
             return;
         }
 
         if (getHelpPageMap().isEmpty() || !getHelpPageMap().containsKey(page)) {
-            commandSender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
-                    + Objects.requireNonNull(getPluginInstance().getLangConfig().getString("invalid-page-message")).replace("{pages}", String.valueOf(getHelpPageMap().size()))));
+            placeholders.put("pages", String.valueOf(getHelpPageMap().size()));
+            commandSender.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_PAGE, placeholders));
             return;
         }
 
@@ -837,23 +810,23 @@ public class Commands implements CommandExecutor {
             Player player = (Player) commandSender;
             List<String> pageLines = getHelpPageMap().get(page);
 
-            player.sendMessage(getPluginInstance().getManager().colorText("\n&e&m---------------&d[ &bSP Help &e(&a" + page + "&e) &d]&e&m---------------"));
+            player.sendMessage(LangConfig.colorText("\n&e&m---------------&d[ &bSP Help &e(&a" + page + "&e) &d]&e&m---------------"));
             for (int i = -1; ++i < pageLines.size(); )
-                player.sendMessage(getPluginInstance().getManager().colorText(pageLines.get(i)));
+                player.sendMessage(LangConfig.colorText(pageLines.get(i)));
 
             if (page < getHelpPageMap().size() && page > 1) {
                 // page is both below the max page and above 1
-                TextComponent footerMessage1 = new TextComponent(getPluginInstance().getManager().colorText("&e&m-------&r&d[")),
-                        footerExtra1 = new TextComponent(getPluginInstance().getManager().colorText(" &b(Previous Page)")),
-                        footerExtra2 = new TextComponent(getPluginInstance().getManager().colorText(" &b(Next Page) ")),
-                        footerEnd = new TextComponent(getPluginInstance().getManager().colorText("&d]&e&m--------\n"));
+                TextComponent footerMessage1 = new TextComponent(LangConfig.colorText("&e&m-------&r&d[")),
+                        footerExtra1 = new TextComponent(LangConfig.colorText(" &b(Previous Page)")),
+                        footerExtra2 = new TextComponent(LangConfig.colorText(" &b(Next Page) ")),
+                        footerEnd = new TextComponent(LangConfig.colorText("&d]&e&m--------\n"));
 
                 footerExtra1.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/portals help " + (page - 1)));
                 footerExtra1.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                        new BaseComponent[]{new TextComponent(getPluginInstance().getManager().colorText("&aClicking this will open the help menu at page &e" + (page - 1) + "&a."))}));
+                        new BaseComponent[]{new TextComponent(LangConfig.colorText("&aClicking this will open the help menu at page &e" + (page - 1) + "&a."))}));
                 footerExtra2.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/portals help " + (page + 1)));
                 footerExtra2.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                        new BaseComponent[]{new TextComponent(getPluginInstance().getManager().colorText("&aClicking this will open the help menu at page &e" + (page + 1) + "&a."))}));
+                        new BaseComponent[]{new TextComponent(LangConfig.colorText("&aClicking this will open the help menu at page &e" + (page + 1) + "&a."))}));
 
                 footerMessage1.addExtra(footerExtra1);
                 footerMessage1.addExtra(footerExtra2);
@@ -862,12 +835,12 @@ public class Commands implements CommandExecutor {
                 player.spigot().sendMessage(footerMessage1);
             } else if (page < getHelpPageMap().size() && page <= 1) {
                 // page is less than or = to 1
-                TextComponent footerMessage = new TextComponent(getPluginInstance().getManager().colorText("&e&m---------------&r&d[")),
-                        footerExtra = new TextComponent(getPluginInstance().getManager().colorText(" &b(Next Page) ")),
-                        footerEnd = new TextComponent(getPluginInstance().getManager().colorText("&d]&e&m---------------\n"));
+                TextComponent footerMessage = new TextComponent(LangConfig.colorText("&e&m---------------&r&d[")),
+                        footerExtra = new TextComponent(LangConfig.colorText(" &b(Next Page) ")),
+                        footerEnd = new TextComponent(LangConfig.colorText("&d]&e&m---------------\n"));
 
                 footerExtra.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/portals help " + (page + 1)));
-                footerExtra.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new BaseComponent[]{new TextComponent(getPluginInstance().getManager().colorText("&aClicking this will open the" +
+                footerExtra.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new BaseComponent[]{new TextComponent(LangConfig.colorText("&aClicking this will open the" +
                         " help menu at page &e" + (page + 1) + "&a."))}));
                 footerMessage.addExtra(footerExtra);
                 footerMessage.addExtra(footerEnd);
@@ -875,25 +848,25 @@ public class Commands implements CommandExecutor {
                 player.spigot().sendMessage(footerMessage);
             } else if (page >= getHelpPageMap().size() && page > 1) {
                 // page at/above max page and greater that 1
-                TextComponent footerMessage = new TextComponent(getPluginInstance().getManager().colorText("&d[&e&m------------&r&d]")),
-                        footerExtra = new TextComponent(getPluginInstance().getManager().colorText(" &b(Previous Page) ")),
-                        footerEnd = new TextComponent(getPluginInstance().getManager().colorText("&d]&e&m-------------\n"));
+                TextComponent footerMessage = new TextComponent(LangConfig.colorText("&d[&e&m------------&r&d]")),
+                        footerExtra = new TextComponent(LangConfig.colorText(" &b(Previous Page) ")),
+                        footerEnd = new TextComponent(LangConfig.colorText("&d]&e&m-------------\n"));
 
                 footerExtra.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/portals help " + (page - 1)));
-                footerExtra.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new BaseComponent[]{new TextComponent(getPluginInstance().getManager().colorText("&aClicking this will open the" +
+                footerExtra.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new BaseComponent[]{new TextComponent(LangConfig.colorText("&aClicking this will open the" +
                         " help menu at page &e" + (page - 1) + "&a."))}));
                 footerMessage.addExtra(footerExtra);
                 footerMessage.addExtra(footerEnd);
 
                 player.spigot().sendMessage(footerMessage);
             } else
-                player.sendMessage(getPluginInstance().getManager().colorText("&d[&e&m---------------------------------------&r&d]\n"));
+                player.sendMessage(LangConfig.colorText("&d[&e&m---------------------------------------&r&d]\n"));
         } else {
             List<String> pageLines = getHelpPageMap().get(page);
-            commandSender.sendMessage(getPluginInstance().getManager().colorText("&d[&e&m-------------&r&d] &bSP Help &e(&a" + page + "&e) &d[&e&m-------------&r&d]"));
+            commandSender.sendMessage(LangConfig.colorText("&d[&e&m-------------&r&d] &bSP Help &e(&a" + page + "&e) &d[&e&m-------------&r&d]"));
             for (int i = -1; ++i < pageLines.size(); )
-                commandSender.sendMessage(getPluginInstance().getManager().colorText(pageLines.get(i)));
-            commandSender.sendMessage(getPluginInstance().getManager().colorText("&d[&e&m---------------------------------------&r&d]\n"));
+                commandSender.sendMessage(LangConfig.colorText(pageLines.get(i)));
+            commandSender.sendMessage(LangConfig.colorText("&d[&e&m---------------------------------------&r&d]\n"));
         }
     }
 

--- a/src/main/java/xzot1k/plugins/sp/core/Commands.java
+++ b/src/main/java/xzot1k/plugins/sp/core/Commands.java
@@ -416,7 +416,7 @@ public class Commands implements CommandExecutor {
         final String worldName = args[2];
         if (getPluginInstance().getServer().getWorlds().parallelStream().noneMatch(world -> world.getName().equalsIgnoreCase(worldName))) {
             placeholders.put("world", worldName);
-            player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_WORLD_KEY, placeholders));
+            player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_WORLD, placeholders));
             return;
         }
 

--- a/src/main/java/xzot1k/plugins/sp/core/Commands.java
+++ b/src/main/java/xzot1k/plugins/sp/core/Commands.java
@@ -486,7 +486,7 @@ public class Commands implements CommandExecutor {
 
                 World world = getPluginInstance().getServer().getWorld(foundPointOne.getWorldName());
                 if (world == null) {
-                    placeholders.put("name", foundPointOne.getWorldName());
+                    placeholders.put("world", foundPointOne.getWorldName());
                     player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.get().get(LangKey.INVALID_WORLD, placeholders));
                     return;
                 }

--- a/src/main/java/xzot1k/plugins/sp/core/Commands.java
+++ b/src/main/java/xzot1k/plugins/sp/core/Commands.java
@@ -15,6 +15,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import xzot1k.plugins.sp.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.objects.Portal;
 import xzot1k.plugins.sp.api.objects.Region;
@@ -626,10 +627,10 @@ public class Commands implements CommandExecutor {
             return;
         }
 
-        if (getPluginInstance().getConfig().getBoolean("management-task")) {
-            getPluginInstance().reloadConfigs();
+        getPluginInstance().reloadConfigs();
+        if (Config.get().managementTask) {
             getPluginInstance().getManager().loadPortals();
-        } else getPluginInstance().reloadConfigs();
+        }
 
         sender.sendMessage(getPluginInstance().getManager().colorText(getPluginInstance().getLangConfig().getString("prefix")
                 + getPluginInstance().getLangConfig().getString("reload-message")));

--- a/src/main/java/xzot1k/plugins/sp/core/Listeners.java
+++ b/src/main/java/xzot1k/plugins/sp/core/Listeners.java
@@ -23,6 +23,7 @@ import org.bukkit.event.vehicle.VehicleMoveEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
+import xzot1k.plugins.sp.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.enums.PointType;
 import xzot1k.plugins.sp.api.events.PortalEnterEvent;
@@ -36,10 +37,7 @@ import java.lang.reflect.Method;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
@@ -48,12 +46,12 @@ import static org.bukkit.GameMode.CREATIVE;
 public class Listeners implements Listener {
 
     private final SimplePortals pluginInstance;
-    private final List<UUID> PortalToPortalProtectionList;
+    private final HashSet<UUID> ptpProtectionPlayers;
     private final HashMap<UUID, TransferData> transferData;
 
     public Listeners(SimplePortals pluginInstance) {
         this.pluginInstance = pluginInstance;
-        this.PortalToPortalProtectionList = new ArrayList<>();
+        this.ptpProtectionPlayers = new HashSet<>();
         this.transferData = new HashMap<>();
     }
 
@@ -117,8 +115,8 @@ public class Listeners implements Listener {
     public void onPreJoin(AsyncPlayerPreLoginEvent e) {
         if (pluginInstance.getDatabaseConnection() == null) return;
 
-        final String serverName = pluginInstance.getConfig().getString("mysql.server-name"),
-                table = pluginInstance.getConfig().getString("mysql.transfer-table");
+        final String serverName = Config.get().mysqlServerName,
+                table = Config.get().mysqlTransferTable;
 
         CompletableFuture<TransferData> destinationFuture = CompletableFuture.supplyAsync(() -> {
             try (PreparedStatement statement = pluginInstance.getDatabaseConnection().prepareStatement("SELECT * FROM " + table + " WHERE uuid = '" + e.getUniqueId() + "';");
@@ -157,7 +155,7 @@ public class Listeners implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onQuit(PlayerQuitEvent e) {
         pluginInstance.getManager().getSmartTransferMap().remove(e.getPlayer().getUniqueId());
-        getPTPProtectionList().remove(e.getPlayer().getUniqueId());
+        getPTPProtectionPlayers().remove(e.getPlayer().getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
@@ -188,9 +186,9 @@ public class Listeners implements Listener {
         if (e.getPlayer().getWorld().getEnvironment() != World.Environment.THE_END) return;
 
         // we don't want it to mess with deaths too if that config option is set to false
-        if (!pluginInstance.getConfig().getBoolean("end-portal-locations-handle-death")) return;
+        if (!Config.get().endOverrideDeath) return;
 
-        Location respawnLocation = pluginInstance.getManager().getVanillaPortalReplacement(e.getPlayer().getWorld(), PortalType.ENDER);
+        Location respawnLocation = pluginInstance.getManager().handleVanillaPortalReplacements(e.getPlayer().getWorld(), PortalType.ENDER);
         if (respawnLocation != null) e.setRespawnLocation(respawnLocation);
     }
 
@@ -214,7 +212,7 @@ public class Listeners implements Listener {
     public void onTeleportDestinationCheck(PlayerTeleportEvent e) {
         Portal fromPortal = pluginInstance.getManager().getPortalAtLocation(e.getFrom()),
                 toPortal = pluginInstance.getManager().getPortalAtLocation(e.getTo());
-        if (fromPortal != null && toPortal != null && !toPortal.isDisabled()) getPTPProtectionList().add(e.getPlayer().getUniqueId());
+        if (fromPortal != null && toPortal != null && !toPortal.isDisabled()) getPTPProtectionPlayers().add(e.getPlayer().getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -224,7 +222,7 @@ public class Listeners implements Listener {
     public void onPortalEntry(PlayerPortalEvent e) {
         if (e.getPlayer().getGameMode() == GameMode.CREATIVE && pluginInstance.getManager().isPortalNearby(e.getFrom(), 5)) e.setCancelled(true);
 
-        if (pluginInstance.getConfig().getBoolean("block-creative-portal-entrance") && e.getPlayer().getGameMode() == CREATIVE) {
+        if (Config.get().blockCreativePortal && e.getPlayer().getGameMode() == CREATIVE) {
             for (Portal portal : pluginInstance.getManager().getPortalMap().values()) {
                 SerializableLocation centerPortal = new SerializableLocation(pluginInstance, portal.getRegion().getPoint1().getWorldName(),
                         ((portal.getRegion().getPoint1().getX() + portal.getRegion().getPoint2().getX()) / 2),
@@ -258,33 +256,30 @@ public class Listeners implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onItemSpawn(ItemSpawnEvent e) {
-        if (pluginInstance.getConfig().getBoolean("item-transfer"))
+        if (Config.get().itemTransfer)
             pluginInstance.getServer().getScheduler().runTaskLater(pluginInstance,
                     () -> initiatePortalStuff(e.getEntity().getLocation(), e.getLocation(), e.getEntity()),
-                    20L * pluginInstance.getConfig().getInt("item-teleport-delay"));
+                    20L * Config.get().itemTeleportDelay);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onItemSpawn(PlayerDropItemEvent e) {
-        if (pluginInstance.getConfig().getBoolean("item-transfer")) {
+        if (Config.get().itemTransfer) {
             final Location startLocation = e.getItemDrop().getLocation().clone();
             pluginInstance.getServer().getScheduler().runTaskLater(pluginInstance,
                     () -> initiatePortalStuff(e.getItemDrop().getLocation(), startLocation, e.getItemDrop()),
-                    20L * pluginInstance.getConfig().getInt("item-teleport-delay"));
+                    20L * Config.get().itemTeleportDelay);
         }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onSpawn(CreatureSpawnEvent e) {
-        List<String> blockedMobs = pluginInstance.getConfig().getStringList("creature-spawning-blacklist");
-        for (int i = -1; ++i < blockedMobs.size(); ) {
-            String blockedMob = blockedMobs.get(i);
-            if (blockedMob.replace(" ", "_").replace("-", "_").equalsIgnoreCase(e.getEntity().getType().name())) {
-                Portal portal = pluginInstance.getManager().getPortalAtLocation(e.getLocation());
-                if (portal != null && !portal.isDisabled()) e.setCancelled(true);
-                break;
-            }
-        }
+        if (!Config.get().creatureBlacklist.contains(e.getEntityType()))
+            return;
+
+        Portal portal = pluginInstance.getManager().getPortalAtLocation(e.getLocation());
+        if (portal != null && !portal.isDisabled())
+            e.setCancelled(true);
     }
 
     // helpers
@@ -294,7 +289,7 @@ public class Listeners implements Listener {
         if (portal == null) {
             if (isPlayer) {
                 final Player player = ((Player) entity);
-                getPTPProtectionList().remove(player.getUniqueId());
+                getPTPProtectionPlayers().remove(player.getUniqueId());
             }
 
             final Portal foundPortal = pluginInstance.getManager().getEntitiesInTeleportationAndPortals().getOrDefault(entity.getUniqueId(), null);
@@ -321,7 +316,7 @@ public class Listeners implements Listener {
                 final Player player = (Player) entity;
 
                 // prevent teleporting due to join protection
-                if (pluginInstance.getConfig().getBoolean("join-protection") && getPTPProtectionList().contains(player.getUniqueId())) return;
+                if (Config.get().ptpProtection && getPTPProtectionPlayers().contains(player.getUniqueId())) return;
 
                 TeleportTask teleportTask = pluginInstance.getManager().getTeleportTasks().getOrDefault(player.getUniqueId(), null);
                 if (teleportTask != null && !teleportTask.isCancelled()) return;
@@ -339,9 +334,9 @@ public class Listeners implements Listener {
             if (isPlayer) {
                 final Player player = (Player) entity;
                 final boolean canBypassCooldown = (player.hasPermission("simpleportals.cdbypass") || player.hasPermission("simpleportals.admin")),
-                        cooldownFail = (pluginInstance.getConfig().getBoolean("use-portal-cooldown")
-                                && (pluginInstance.getManager().isPlayerOnCooldown(player, "normal", pluginInstance.getConfig().getInt("portal-cooldown-duration"))) && !canBypassCooldown),
-                        permissionFail = !pluginInstance.getConfig().getBoolean("bypass-portal-permissions")
+                        cooldownFail = (Config.get().usePortalCooldown
+                                && (pluginInstance.getManager().isPlayerOnCooldown(player, "normal", Config.get().cooldownDuration)) && !canBypassCooldown),
+                        permissionFail = !Config.get().bypassPortalPermissions
                                 && (!player.hasPermission("simpleportals.portal." + portal.getPortalId())
                                 && !player.hasPermission("simpleportals.portals." + portal.getPortalId())
                                 && !player.hasPermission("simpleportals.portal.*")
@@ -349,7 +344,7 @@ public class Listeners implements Listener {
                                 && !player.hasPermission("simpleportals.admin"));
 
                 if (cooldownFail || permissionFail) {
-                    double tv = pluginInstance.getConfig().getDouble("throw-velocity");
+                    double tv = Config.get().throwVelocity;
                     if (!(tv <= -1)) {
                         final Vector direction = new Vector(fromLocation.getX() - toLocation.getX(),
                                 ((fromLocation.getY() - toLocation.getY()) + (player.getVelocity().getY() / 2)),
@@ -362,12 +357,12 @@ public class Listeners implements Listener {
                     if (message != null && !message.equalsIgnoreCase(""))
                         player.sendMessage(pluginInstance.getManager().colorText(pluginInstance.getLangConfig().getString("prefix")
                                 + message.replace("{time}", String.valueOf(pluginInstance.getManager().getCooldownTimeLeft(player, "normal",
-                                pluginInstance.getConfig().getInt("portal-cooldown-duration"))))));
+                                Config.get().cooldownDuration)))));
                     return;
                 }
             }
 
-            if (isPlayer && pluginInstance.getConfig().getBoolean("use-portal-cooldown")) {
+            if (isPlayer && Config.get().usePortalCooldown) {
                 final Player player = (Player) entity;
                 final boolean canBypassCooldown = player.hasPermission("simpleportals.cdbypass");
                 if (!canBypassCooldown) pluginInstance.getManager().updatePlayerPortalCooldown((Player) entity, "normal");
@@ -379,28 +374,28 @@ public class Listeners implements Listener {
                     if (portal.getMessage() != null && !portal.getMessage().isEmpty())
                         player.sendMessage(pluginInstance.getManager().colorText(portal.getMessage().replace("{name}", portal.getPortalId())
                                 .replace("{time}", String.valueOf(pluginInstance.getManager().getCooldownTimeLeft(player, "normal",
-                                        pluginInstance.getConfig().getInt("portal-cooldown-duration"))))));
+                                        Config.get().cooldownDuration)))));
 
                     if (portal.getBarMessage() != null && !portal.getBarMessage().isEmpty())
                         pluginInstance.getManager().sendBarMessage(player, portal.getBarMessage().replace("{name}", portal.getPortalId())
                                 .replace("{time}", String.valueOf(pluginInstance.getManager().getCooldownTimeLeft(player, "normal",
-                                        pluginInstance.getConfig().getInt("portal-cooldown-duration")))));
+                                        Config.get().cooldownDuration))));
 
                     if ((portal.getTitle() != null && !portal.getTitle().isEmpty()) && (portal.getSubTitle() != null && !portal.getSubTitle().isEmpty()))
                         pluginInstance.getManager().sendTitle(player, portal.getTitle().replace("{name}", portal.getPortalId())
                                         .replace("{time}", String.valueOf(pluginInstance.getManager().getCooldownTimeLeft(player,
-                                                "normal", pluginInstance.getConfig().getInt("portal-cooldown-duration")))),
+                                                "normal", Config.get().cooldownDuration))),
                                 portal.getSubTitle().replace("{name}", portal.getPortalId())
                                         .replace("{time}", String.valueOf(pluginInstance.getManager().getCooldownTimeLeft(player,
-                                                "normal", pluginInstance.getConfig().getInt("portal-cooldown-duration")))));
+                                                "normal", Config.get().cooldownDuration))));
                     else if (portal.getTitle() != null && !portal.getTitle().isEmpty())
                         pluginInstance.getManager().sendTitle(player, portal.getTitle().replace("{name}", portal.getPortalId())
                                 .replace("{time}", String.valueOf(pluginInstance.getManager().getCooldownTimeLeft(player,
-                                        "normal", pluginInstance.getConfig().getInt("portal-cooldown-duration")))), null);
+                                        "normal", Config.get().cooldownDuration))), null);
                     else if (portal.getSubTitle() != null && !portal.getSubTitle().isEmpty())
                         pluginInstance.getManager().sendTitle(player, null, portal.getSubTitle().replace("{name}", portal.getPortalId())
                                 .replace("{time}", String.valueOf(pluginInstance.getManager().getCooldownTimeLeft(player,
-                                        "normal", pluginInstance.getConfig().getInt("portal-cooldown-duration")))));
+                                        "normal", Config.get().cooldownDuration))));
                 }
 
                 portal.performAction(entity);
@@ -452,8 +447,8 @@ public class Listeners implements Listener {
     }
 
     private void forceJoin(@NotNull Player player) {
-        if (pluginInstance.getConfig().getBoolean("force-join")) {
-            final String worldName = pluginInstance.getConfig().getString("force-join-world");
+        if (Config.get().forceJoin) {
+            final String worldName = Config.get().forceJoinWorld;
             if (worldName != null && worldName.isEmpty()) {
                 if (player.getWorld().getSpawnLocation() != null) player.teleport(player.getWorld().getSpawnLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
             } else {
@@ -464,20 +459,20 @@ public class Listeners implements Listener {
     }
 
     private void checkPTPProtection(@NotNull Player player) {
-        if (pluginInstance.getConfig().getBoolean("portal-to-portal-protection")) {
+        if (Config.get().ptpProtection) {
             Portal portal = pluginInstance.getManager().getPortalAtLocation(player.getLocation());
             if (portal == null || portal.isDisabled()) return;
 
-            getPTPProtectionList().add(player.getUniqueId());
+            getPTPProtectionPlayers().add(player.getUniqueId());
         }
     }
 
     // getters & setters
 
     /**
-     * @return The list of users who will be blocked from teleporting in a portal they join, spawn, or teleport into
+     * @return The Set of users who will be blocked from teleporting in a portal they join, spawn, or teleport into
      */
-    public List<UUID> getPTPProtectionList() {return PortalToPortalProtectionList;}
+    public HashSet<UUID> getPTPProtectionPlayers() {return ptpProtectionPlayers;}
 
     public HashMap<UUID, TransferData> getTransferData() {return transferData;}
 }

--- a/src/main/java/xzot1k/plugins/sp/core/Listeners.java
+++ b/src/main/java/xzot1k/plugins/sp/core/Listeners.java
@@ -23,13 +23,15 @@ import org.bukkit.event.vehicle.VehicleMoveEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
-import xzot1k.plugins.sp.Config;
+import xzot1k.plugins.sp.config.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.enums.PointType;
 import xzot1k.plugins.sp.api.events.PortalEnterEvent;
 import xzot1k.plugins.sp.api.objects.Portal;
 import xzot1k.plugins.sp.api.objects.SerializableLocation;
 import xzot1k.plugins.sp.api.objects.TransferData;
+import xzot1k.plugins.sp.config.LangConfig;
+import xzot1k.plugins.sp.config.LangKey;
 import xzot1k.plugins.sp.core.tasks.TeleportTask;
 
 import java.lang.reflect.InvocationTargetException;
@@ -68,10 +70,9 @@ public class Listeners implements Listener {
             e.setCancelled(true);
             if (pluginInstance.getManager().updateCurrentSelection(e.getPlayer(), e.getClickedBlock().getLocation(), PointType.POINT_ONE)) {
                 pluginInstance.getManager().highlightBlock(e.getClickedBlock(), e.getPlayer(), PointType.POINT_ONE);
-                String message = pluginInstance.getLangConfig().getString("point-1-set-message");
+                String message = LangConfig.get().get(LangKey.POINT1_SET);
                 if (message != null && !message.equalsIgnoreCase(""))
-                    e.getPlayer().sendMessage(pluginInstance.getManager()
-                            .colorText(pluginInstance.getLangConfig().getString("prefix") + message));
+                    e.getPlayer().sendMessage(LangConfig.get().get(LangKey.PREFIX) + message);
             }
         }
 
@@ -84,9 +85,9 @@ public class Listeners implements Listener {
             if (pluginInstance.getManager().updateCurrentSelection(e.getPlayer(), e.getClickedBlock().getLocation(), PointType.POINT_TWO)) {
                 pluginInstance.getManager().highlightBlock(e.getClickedBlock(), e.getPlayer(), PointType.POINT_TWO);
 
-                String message = pluginInstance.getLangConfig().getString("point-2-set-message");
-                if (message != null && !message.equalsIgnoreCase(""))
-                    e.getPlayer().sendMessage(pluginInstance.getManager().colorText(pluginInstance.getLangConfig().getString("prefix") + message));
+                String message = LangConfig.get().get(LangKey.POINT2_SET);
+                if (message != null && !message.isEmpty())
+                    e.getPlayer().sendMessage(LangConfig.get().get(LangKey.PREFIX) + message);
             }
         }
     }
@@ -302,11 +303,10 @@ public class Listeners implements Listener {
                 if (teleportTask != null) teleportTask.cancel();
                 pluginInstance.getManager().getTeleportTasks().remove(player.getUniqueId());
 
-                String title = pluginInstance.getLangConfig().getString("teleport-cancelled.title"),
-                        subTitle = pluginInstance.getLangConfig().getString("teleport-cancelled.sub-title");
+                String title = LangConfig.get().get(LangKey.TELEPORT_CANCELLED_TITLE),
+                        subTitle = LangConfig.get().get(LangKey.TELEPORT_CANCELLED_SUBTITLE);
                 if ((title != null && !title.isEmpty()) || (subTitle != null && !subTitle.isEmpty())) {
-                    player.sendTitle(pluginInstance.getManager().colorText(title),
-                            pluginInstance.getManager().colorText(subTitle), 0, 40, 0);
+                    player.sendTitle(title, subTitle, 0, 40, 0);
                 }
             }
         }
@@ -352,12 +352,17 @@ public class Listeners implements Listener {
                         player.setVelocity(direction);
                     }
 
-                    String message = cooldownFail ? pluginInstance.getLangConfig().getString("enter-cooldown-message")
-                            : pluginInstance.getLangConfig().getString("enter-no-permission-message");
-                    if (message != null && !message.equalsIgnoreCase(""))
-                        player.sendMessage(pluginInstance.getManager().colorText(pluginInstance.getLangConfig().getString("prefix")
-                                + message.replace("{time}", String.valueOf(pluginInstance.getManager().getCooldownTimeLeft(player, "normal",
-                                Config.get().cooldownDuration)))));
+                    String message = cooldownFail ? LangConfig.get().get(LangKey.ENTER_COOLDOWN)
+                            : LangConfig.get().get(LangKey.ENTER_NO_PERMISSION);
+                    if (message != null && !message.equalsIgnoreCase("")) {
+                        HashMap<String, String> placeholders = new HashMap<>();
+                        placeholders.put("time",
+                                String.valueOf(pluginInstance.getManager()
+                                        .getCooldownTimeLeft(player, "normal", Config.get().cooldownDuration)
+                                )
+                        );
+                        player.sendMessage(LangConfig.get().get(LangKey.PREFIX) + LangConfig.parsePlaceholders(message, placeholders));
+                    }
                     return;
                 }
             }
@@ -372,7 +377,7 @@ public class Listeners implements Listener {
                 if (isPlayer) {
                     final Player player = (Player) entity;
                     if (portal.getMessage() != null && !portal.getMessage().isEmpty())
-                        player.sendMessage(pluginInstance.getManager().colorText(portal.getMessage().replace("{name}", portal.getPortalId())
+                        player.sendMessage(LangConfig.colorText(portal.getMessage().replace("{name}", portal.getPortalId())
                                 .replace("{time}", String.valueOf(pluginInstance.getManager().getCooldownTimeLeft(player, "normal",
                                         Config.get().cooldownDuration)))));
 

--- a/src/main/java/xzot1k/plugins/sp/core/packets/bar/ABH_Latest.java
+++ b/src/main/java/xzot1k/plugins/sp/core/packets/bar/ABH_Latest.java
@@ -8,12 +8,12 @@ import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
-import xzot1k.plugins.sp.SimplePortals;
+import xzot1k.plugins.sp.config.LangConfig;
 
 public class ABH_Latest implements BarHandler {
     @Override
     public void sendActionBar(@NotNull Player player, @NotNull String message) {
-        player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(SimplePortals.getPluginInstance().getManager().colorText(message)));
+        player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(LangConfig.colorText(message)));
     }
 
 }

--- a/src/main/java/xzot1k/plugins/sp/core/packets/bar/ABH_Old.java
+++ b/src/main/java/xzot1k/plugins/sp/core/packets/bar/ABH_Old.java
@@ -7,6 +7,7 @@ package xzot1k.plugins.sp.core.packets.bar;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import xzot1k.plugins.sp.SimplePortals;
+import xzot1k.plugins.sp.config.LangConfig;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -39,7 +40,7 @@ public class ABH_Old implements BarHandler {
         try {
             final Method method = csClass.getDeclaredMethod("a", String.class);
             final Object icbc = method.invoke(csClass, ("{\"text\": \""
-                    + SimplePortals.getPluginInstance().getManager().colorText(message) + "\"}"));
+                    + LangConfig.colorText(message) + "\"}"));
 
             Constructor<?> packetConstructor = null;
             for (Constructor<?> con : packetChatClass.getConstructors()) {

--- a/src/main/java/xzot1k/plugins/sp/core/packets/titles/versions/Titles_Latest.java
+++ b/src/main/java/xzot1k/plugins/sp/core/packets/titles/versions/Titles_Latest.java
@@ -6,6 +6,7 @@ package xzot1k.plugins.sp.core.packets.titles.versions;
 
 import org.bukkit.entity.Player;
 import xzot1k.plugins.sp.SimplePortals;
+import xzot1k.plugins.sp.config.LangConfig;
 import xzot1k.plugins.sp.core.packets.titles.TitleHandler;
 
 public class Titles_Latest implements TitleHandler {
@@ -17,12 +18,12 @@ public class Titles_Latest implements TitleHandler {
 
     @Override
     public void sendSubTitle(Player player, String text, int fadeIn, int displayTime, int fadeOut) {
-        player.sendTitle("", SimplePortals.getPluginInstance().getManager().colorText(text), fadeIn * 20, displayTime * 20, fadeOut * 20);
+        player.sendTitle("", LangConfig.colorText(text), fadeIn * 20, displayTime * 20, fadeOut * 20);
     }
 
     @Override
     public void sendTitle(Player player, String title, String subTitle, int fadeIn, int displayTime, int fadeOut) {
-        player.sendTitle(SimplePortals.getPluginInstance().getManager().colorText(title), SimplePortals.getPluginInstance().getManager().colorText(subTitle),
+        player.sendTitle(LangConfig.colorText(title), LangConfig.colorText(subTitle),
                 fadeIn * 20, displayTime * 20, fadeOut * 20);
     }
 

--- a/src/main/java/xzot1k/plugins/sp/core/packets/titles/versions/Titles_Old.java
+++ b/src/main/java/xzot1k/plugins/sp/core/packets/titles/versions/Titles_Old.java
@@ -7,6 +7,7 @@ package xzot1k.plugins.sp.core.packets.titles.versions;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import xzot1k.plugins.sp.SimplePortals;
+import xzot1k.plugins.sp.config.LangConfig;
 import xzot1k.plugins.sp.core.packets.titles.TitleHandler;
 
 import java.lang.reflect.Constructor;
@@ -55,7 +56,7 @@ public class Titles_Old implements TitleHandler {
 
             final Method aMethod = csClass.getDeclaredMethod("a", String.class);
 
-            final String coloredText = SimplePortals.getPluginInstance().getManager().colorText(text);
+            final String coloredText = LangConfig.colorText(text);
             final Object textField = aMethod.invoke(csClass, "{\"text\":\"" + coloredText + "\"}");
 
 

--- a/src/main/java/xzot1k/plugins/sp/core/tasks/HighlightTask.java
+++ b/src/main/java/xzot1k/plugins/sp/core/tasks/HighlightTask.java
@@ -8,6 +8,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
+import xzot1k.plugins.sp.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.objects.SerializableLocation;
 
@@ -23,7 +24,7 @@ public class HighlightTask extends BukkitRunnable {
     public HighlightTask(SimplePortals pluginInstance, Player player, Location blockLocation, String particleEffect) {
         setPluginInstance(pluginInstance);
         setBlockLocation(new SerializableLocation(pluginInstance, blockLocation));
-        setDuration(getPluginInstance().getConfig().getInt("selection-visual-duration"));
+        setDuration(Config.get().selectionDuration);
         setPlayer(player);
         setWorld(blockLocation.getWorld());
         setParticleEffect(particleEffect);

--- a/src/main/java/xzot1k/plugins/sp/core/tasks/HighlightTask.java
+++ b/src/main/java/xzot1k/plugins/sp/core/tasks/HighlightTask.java
@@ -8,7 +8,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
-import xzot1k.plugins.sp.Config;
+import xzot1k.plugins.sp.config.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.objects.SerializableLocation;
 

--- a/src/main/java/xzot1k/plugins/sp/core/tasks/RegionTask.java
+++ b/src/main/java/xzot1k/plugins/sp/core/tasks/RegionTask.java
@@ -8,6 +8,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
+import xzot1k.plugins.sp.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.objects.Portal;
 
@@ -22,10 +23,10 @@ public class RegionTask extends BukkitRunnable {
 
     public RegionTask(SimplePortals pluginInstance, Player player, Portal portal) {
         setPluginInstance(pluginInstance);
-        setDuration(pluginInstance.getConfig().getInt("region-visual-duration"));
+        setDuration(Config.get().regionDuration);
         setPlayer(player);
         setWorld(getPluginInstance().getServer().getWorld(portal.getRegion().getPoint1().getWorldName()));
-        setParticleEffect(pluginInstance.getConfig().getString("region-visual-effect"));
+        setParticleEffect(Config.get().regionEffect);
         setLifeTime(0);
         setPortal(portal);
     }

--- a/src/main/java/xzot1k/plugins/sp/core/tasks/RegionTask.java
+++ b/src/main/java/xzot1k/plugins/sp/core/tasks/RegionTask.java
@@ -8,7 +8,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
-import xzot1k.plugins.sp.Config;
+import xzot1k.plugins.sp.config.Config;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.objects.Portal;
 

--- a/src/main/java/xzot1k/plugins/sp/core/tasks/TeleportTask.java
+++ b/src/main/java/xzot1k/plugins/sp/core/tasks/TeleportTask.java
@@ -11,6 +11,8 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 import xzot1k.plugins.sp.SimplePortals;
 import xzot1k.plugins.sp.api.objects.Portal;
+import xzot1k.plugins.sp.config.LangConfig;
+import xzot1k.plugins.sp.config.LangKey;
 
 import java.util.HashMap;
 
@@ -54,11 +56,13 @@ public class TeleportTask extends BukkitRunnable {
             if (entity instanceof Player) {
                 final Player player = ((Player) entity);
 
-                String title = INSTANCE.getLangConfig().getString("teleport.title"),
-                        subTitle = INSTANCE.getLangConfig().getString("teleport.sub-title");
+                HashMap<String, String> placeholders = new HashMap<>();
+                placeholders.put("rem", String.valueOf(rem));
+
+                String title = LangConfig.get().get(LangKey.TELEPORT_TITLE),
+                        subTitle = LangConfig.get().get(LangKey.TELEPORT_SUBTITLE, placeholders);
                 if ((title != null && !title.isEmpty()) || (subTitle != null && !subTitle.isEmpty())) {
-                    player.sendTitle(INSTANCE.getManager().colorText(title), INSTANCE.getManager().colorText(subTitle
-                            .replace("{rem}", String.valueOf(rem))), 0, 40, 0);
+                    player.sendTitle(title, subTitle, 0, 40, 0);
                 }
             }
 
@@ -80,11 +84,13 @@ public class TeleportTask extends BukkitRunnable {
         if (rem > 0 && entity instanceof Player) {
             final Player player = ((Player) entity);
 
-            String title = INSTANCE.getLangConfig().getString("teleport-delay.title"),
-                    subTitle = INSTANCE.getLangConfig().getString("teleport-delay.sub-title");
+            HashMap<String, String> placeholders = new HashMap<>();
+            placeholders.put("rem", String.valueOf(rem));
+
+            String title = LangConfig.get().get(LangKey.TELEPORT_TITLE),
+                    subTitle = LangConfig.get().get(LangKey.TELEPORT_SUBTITLE, placeholders);
             if ((title != null && !title.isEmpty()) || (subTitle != null && !subTitle.isEmpty())) {
-                player.sendTitle(INSTANCE.getManager().colorText(title), INSTANCE.getManager().colorText(subTitle
-                        .replace("{rem}", String.valueOf(rem))), 0, 40, 0);
+                player.sendTitle(title, subTitle, 0, 40, 0);
             }
         }
     }

--- a/src/main/java/xzot1k/plugins/sp/core/tasks/TeleportTask.java
+++ b/src/main/java/xzot1k/plugins/sp/core/tasks/TeleportTask.java
@@ -59,8 +59,8 @@ public class TeleportTask extends BukkitRunnable {
                 HashMap<String, String> placeholders = new HashMap<>();
                 placeholders.put("rem", String.valueOf(rem));
 
-                String title = LangConfig.get().get(LangKey.TELEPORT_TITLE),
-                        subTitle = LangConfig.get().get(LangKey.TELEPORT_SUBTITLE, placeholders);
+                String title = LangConfig.get().get(LangKey.TELEPORT_DELAY_TITLE),
+                        subTitle = LangConfig.get().get(LangKey.TELEPORT_DELAY_SUBTITLE, placeholders);
                 if ((title != null && !title.isEmpty()) || (subTitle != null && !subTitle.isEmpty())) {
                     player.sendTitle(title, subTitle, 0, 40, 0);
                 }
@@ -87,8 +87,8 @@ public class TeleportTask extends BukkitRunnable {
             HashMap<String, String> placeholders = new HashMap<>();
             placeholders.put("rem", String.valueOf(rem));
 
-            String title = LangConfig.get().get(LangKey.TELEPORT_TITLE),
-                    subTitle = LangConfig.get().get(LangKey.TELEPORT_SUBTITLE, placeholders);
+            String title = LangConfig.get().get(LangKey.TELEPORT_DELAY_TITLE),
+                    subTitle = LangConfig.get().get(LangKey.TELEPORT_DELAY_SUBTITLE, placeholders);
             if ((title != null && !title.isEmpty()) || (subTitle != null && !subTitle.isEmpty())) {
                 player.sendTitle(title, subTitle, 0, 40, 0);
             }

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -6,7 +6,6 @@ portal-location-exists-message: "&cThe portal &e{name} &cexists at this location
 portal-exists-message: "&cThe portal &e{name} &calready exists. Please use the &erelocate &ccommand or re-create the portal."
 selected-region-invalid-message: "&cPlease check your selected region. It seems one of your points or the entire region is invalid."
 portal-invalid-message: "&cThe portal &e{name} &cdoes not exist."
-world-invalid-message: "&cThe world &e{name} &cdoes not exist."
 selection-mode-message: "&aSelection mode has be &e{status}&a! Within selection mode, use &eLeft &aand &eRight &aclick to create a cuboid selection."
 not-same-world-message: "&cBoth points within your selection must be in the same world."
 portal-created-message: "&aThe portal &e{name} &ahas been successfully created!"


### PR DESCRIPTION
By caching configs the workload is reduced by a lot, fixing #35 .
I also noticed that there were some inconsistencies with inexistent config sections and lang messages, I should have highlighted those with comments in the code

Other changes:
Improved handleVanillaPortalReplacements by storing them once when loading the config
Changed ptpProtectionPlayers from ArrayList to HashSet

I already tested this in prod for almost two days now and everything seems good.