### PR TITLE
Fix AntiVirus false flags

### DIFF
--- a/src/main/java/xzot1k/plugins/sp/api/enums/PortalCommandType.java
+++ b/src/main/java/xzot1k/plugins/sp/api/enums/PortalCommandType.java
@@ -8,8 +8,10 @@ public enum PortalCommandType {
     CONSOLE, PLAYER, CHAT;
 
     public static PortalCommandType getType(String typeString) {
+        String commandType = typeString.replace(" ", "_").replace("-", "_");
+
         for (PortalCommandType portalCommandType : PortalCommandType.values())
-            if (portalCommandType.name().equalsIgnoreCase(typeString.replace(" ", "_").replace("-", "_")))
+            if (portalCommandType.name().equalsIgnoreCase(commandType))
                 return portalCommandType;
         return null;
     }


### PR DESCRIPTION
Apparently
`string.equalsIgnoreCase(otherString.replace(" ", "_").replace("-", "_"))`
Is a pretty known pattern used in malwares (ik, this is ridiculous)

VirusTotal scan: https://www.virustotal.com/gui/file/6c7083bc10cde7c4267676483ec25fc8a1e06393d6dd9fe64750a76b295388f9

This fixes #52 and #55 